### PR TITLE
[ANALYTICS-2752] Implement generic OAuth

### DIFF
--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -8,7 +8,7 @@ locals {
     GF_DATABASE_PASSWORD = random_password.password.result
     ### AUTH
     GF_AUTH_GENERIC_OAUTH_ENABLED               = true
-    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP         = false
+    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP         = true
     GF_AUTH_GENERIC_OAUTH_TEAM_IDS              = ""
     GF_AUTH_GENERIC_OAUTH_ALLOWED_ORGANIZATIONS = ""
     GF_AUTH_GENERIC_OAUTH_NAME                  = var.oauth_name

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -1,7 +1,7 @@
 locals {
   grafana_config = {
     GF_SERVER_DOMAIN     = "${var.grafana_subdomain}.${var.dns_name}"
-    GF_SERVER_ROOT_URL  = "https://${var.grafana_subdomain}.${var.dns_name}"
+    GF_SERVER_ROOT_URL   = "https://${var.grafana_subdomain}.${var.dns_name}"
     GF_DATABASE_USER     = var.grafana_db_username
     GF_DATABASE_TYPE     = "mysql"
     GF_DATABASE_HOST     = "${aws_rds_cluster.grafana.endpoint}:3306"
@@ -105,27 +105,3 @@ resource "aws_ecs_service" "grafana" {
 resource "aws_cloudwatch_log_group" "grafana" {
   name = "${var.resource_prefix}-grafana"
 }
-
-# Not used anymore - temp because tf cannot destroy sg while attached
-resource "aws_security_group" "grafana_ecs" {
-  description = "ingress to the grafana fargate task from the alb"
-
-  vpc_id = var.vpc_id
-  name   = "${var.resource_prefix}-grafana-ecs"
-
-  //nginx
-  ingress {
-    protocol        = "tcp"
-    from_port       = 3000
-    to_port         = 3000
-    security_groups = [aws_security_group.grafana_alb.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -15,9 +15,9 @@ locals {
     GF_AUTH_GENERIC_OAUTH_CLIENT_ID             = var.oauth_client_id
     GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET         = var.oauth_client_secret
     GF_AUTH_GENERIC_OAUTH_SCOPES                = "openid profile email"
-    GF_AUTH_GENERIC_OAUTH_AUTH_URL              = "${var.oauth_domain}/authorize"
-    GF_AUTH_GENERIC_OAUTH_TOKEN_URL             = "${var.oauth_domain}/oauth/token"
-    GF_AUTH_GENERIC_OAUTH_API_URL               = "${var.oauth_domain}/userinfo"
+    GF_AUTH_GENERIC_OAUTH_AUTH_URL              = "https://${var.oauth_domain}/authorize"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL             = "https://${var.oauth_domain}/oauth/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL               = "https://${var.oauth_domain}/userinfo"
     GF_AUTH_GENERIC_OAUTH_USE_PKCE              = "True"
   }
 }

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -106,3 +106,26 @@ resource "aws_cloudwatch_log_group" "grafana" {
   name = "${var.resource_prefix}-grafana"
 }
 
+# Not used anymore - temp because tf cannot destroy sg while attached
+resource "aws_security_group" "grafana_ecs" {
+  description = "ingress to the grafana fargate task from the alb"
+
+  vpc_id = var.vpc_id
+  name   = "${var.resource_prefix}-grafana-ecs"
+
+  //nginx
+  ingress {
+    protocol        = "tcp"
+    from_port       = 3000
+    to_port         = 3000
+    security_groups = [aws_security_group.grafana_alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -7,18 +7,18 @@ locals {
     GF_LOG_LEVEL         = var.grafana_log_level
     GF_DATABASE_PASSWORD = random_password.password.result
     ### AUTH
-    GF_AUTH_GENERIC_OAUTH_ENABLED = true
-    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP = false
-    GF_AUTH_GENERIC_OAUTH_TEAM_IDS = ""
+    GF_AUTH_GENERIC_OAUTH_ENABLED               = true
+    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP         = false
+    GF_AUTH_GENERIC_OAUTH_TEAM_IDS              = ""
     GF_AUTH_GENERIC_OAUTH_ALLOWED_ORGANIZATIONS = ""
-    GF_AUTH_GENERIC_OAUTH_NAME = var.oauth_name
-    GF_AUTH_GENERIC_OAUTH_CLIENT_ID = var.oauth_client_id
-    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = var.oauth_client_secret
-    GF_AUTH_GENERIC_OAUTH_SCOPES = "openid profile email"
-    GF_AUTH_GENERIC_OAUTH_AUTH_URL = "${var.oauth_domain}/authorize"
-    GF_AUTH_GENERIC_OAUTH_TOKEN_URL = "${var.oauth_domain}/oauth/token"
-    GF_AUTH_GENERIC_OAUTH_API_URL = "${var.oauth_domain}/userinfo"
-    GF_AUTH_GENERIC_OAUTH_USE_PKCE = true
+    GF_AUTH_GENERIC_OAUTH_NAME                  = var.oauth_name
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID             = var.oauth_client_id
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET         = var.oauth_client_secret
+    GF_AUTH_GENERIC_OAUTH_SCOPES                = "openid profile email"
+    GF_AUTH_GENERIC_OAUTH_AUTH_URL              = "${var.oauth_domain}/authorize"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL             = "${var.oauth_domain}/oauth/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL               = "${var.oauth_domain}/userinfo"
+    GF_AUTH_GENERIC_OAUTH_USE_PKCE              = true
   }
 }
 resource "aws_ecs_cluster" "grafana" {

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -23,7 +23,7 @@ locals {
   }
 }
 resource "aws_ecs_cluster" "grafana" {
-  name = "${var.resource_prefix}-grafana"
+  name = "${var.resource_prefix}-grafana-cluster"
 }
 
 resource "aws_ecr_repository" "grafana" {
@@ -85,7 +85,7 @@ resource "aws_ecs_service" "grafana" {
 
 
   network_configuration {
-    security_groups = [aws_security_group.grafana_ecs.id]
+    security_groups = [var.grafana_ecs_security_group_id]
     subnets         = var.subnets
   }
 
@@ -104,27 +104,5 @@ resource "aws_ecs_service" "grafana" {
 
 resource "aws_cloudwatch_log_group" "grafana" {
   name = "${var.resource_prefix}-grafana"
-}
-
-resource "aws_security_group" "grafana_ecs" {
-  description = "ingress to the grafana fargate task from the alb"
-
-  vpc_id = var.vpc_id
-  name   = "${var.resource_prefix}-grafana-ecs"
-
-  //nginx
-  ingress {
-    protocol        = "tcp"
-    from_port       = 3000
-    to_port         = 3000
-    security_groups = [aws_security_group.grafana_alb.id]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -6,6 +6,19 @@ locals {
     GF_DATABASE_HOST     = "${aws_rds_cluster.grafana.endpoint}:3306"
     GF_LOG_LEVEL         = var.grafana_log_level
     GF_DATABASE_PASSWORD = random_password.password.result
+    ### AUTH
+    GF_AUTH_GENERIC_OAUTH_ENABLED = true
+    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP = false
+    GF_AUTH_GENERIC_OAUTH_TEAM_IDS = ""
+    GF_AUTH_GENERIC_OAUTH_ALLOWED_ORGANIZATIONS = ""
+    GF_AUTH_GENERIC_OAUTH_NAME = var.oauth_name
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID = var.oauth_client_id
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = var.oauth_client_secret
+    GF_AUTH_GENERIC_OAUTH_SCOPES = "openid profile email"
+    GF_AUTH_GENERIC_OAUTH_AUTH_URL = "${var.oauth_domain}/authorize"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL = "${var.oauth_domain}/oauth/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL = "${var.oauth_domain}/userinfo"
+    GF_AUTH_GENERIC_OAUTH_USE_PKCE = true
   }
 }
 resource "aws_ecs_cluster" "grafana" {

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -7,8 +7,8 @@ locals {
     GF_LOG_LEVEL         = var.grafana_log_level
     GF_DATABASE_PASSWORD = random_password.password.result
     ### AUTH
-    GF_AUTH_GENERIC_OAUTH_ENABLED               = true
-    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP         = true
+    GF_AUTH_GENERIC_OAUTH_ENABLED               = "True"
+    GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP         = "True"
     GF_AUTH_GENERIC_OAUTH_TEAM_IDS              = ""
     GF_AUTH_GENERIC_OAUTH_ALLOWED_ORGANIZATIONS = ""
     GF_AUTH_GENERIC_OAUTH_NAME                  = var.oauth_name
@@ -18,7 +18,7 @@ locals {
     GF_AUTH_GENERIC_OAUTH_AUTH_URL              = "${var.oauth_domain}/authorize"
     GF_AUTH_GENERIC_OAUTH_TOKEN_URL             = "${var.oauth_domain}/oauth/token"
     GF_AUTH_GENERIC_OAUTH_API_URL               = "${var.oauth_domain}/userinfo"
-    GF_AUTH_GENERIC_OAUTH_USE_PKCE              = true
+    GF_AUTH_GENERIC_OAUTH_USE_PKCE              = "True"
   }
 }
 resource "aws_ecs_cluster" "grafana" {

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -1,6 +1,7 @@
 locals {
   grafana_config = {
     GF_SERVER_DOMAIN     = "${var.grafana_subdomain}.${var.dns_name}"
+    GF_SERVER_ROOT_URL  = "https://${var.grafana_subdomain}.${var.dns_name}"
     GF_DATABASE_USER     = var.grafana_db_username
     GF_DATABASE_TYPE     = "mysql"
     GF_DATABASE_HOST     = "${aws_rds_cluster.grafana.endpoint}:3306"

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "grafana" {
   name            = "${var.resource_prefix}-grafana"
   internal        = "false"
-  security_groups = [aws_security_group.grafana_alb.id]
+  security_groups = [var.grafana_alb_security_group_id]
   subnets         = var.lb_subnets
   idle_timeout    = "3600"
 
@@ -66,32 +66,3 @@ resource "aws_lb_target_group" "grafana" {
     ManagedBy   = "Terraform"
   }
 }
-
-resource "aws_security_group" "grafana_alb" {
-  description = "the alb security group that allows port 80/443 from whitelisted ips"
-
-  vpc_id = var.vpc_id
-  name   = "${var.resource_prefix}-grafana-alb"
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = var.whitelist_ips
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = var.whitelist_ips
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -66,33 +66,3 @@ resource "aws_lb_target_group" "grafana" {
     ManagedBy   = "Terraform"
   }
 }
-
-# Not used anymore - temp because tf cannot destroy sg while attached
-resource "aws_security_group" "grafana_alb" {
-  description = "the alb security group that allows port 80/443 from whitelisted ips"
-
-  vpc_id = var.vpc_id
-  name   = "${var.resource_prefix}-grafana-alb"
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -66,3 +66,33 @@ resource "aws_lb_target_group" "grafana" {
     ManagedBy   = "Terraform"
   }
 }
+
+# Not used anymore - temp because tf cannot destroy sg while attached
+resource "aws_security_group" "grafana_alb" {
+  description = "the alb security group that allows port 80/443 from whitelisted ips"
+
+  vpc_id = var.vpc_id
+  name   = "${var.resource_prefix}-grafana-alb"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,7 +7,3 @@ output "grafana_role" {
   value = aws_iam_role.grafana_assume.arn
 }
 
-output "grafana_ecs_sg" {
-  value = aws_security_group.grafana_ecs.id
-}
-

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,7 @@ output "grafana_role" {
   value = aws_iam_role.grafana_assume.arn
 }
 
+output "grafana_ecs_sg" {
+  value = aws_security_group.grafana_ecs.id
+}
+

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "rds" {
     to_port     = 3306
 
     security_groups = [
-      aws_security_group.grafana_ecs.id,
+      var.grafana_ecs_security_group_id,
     ]
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,11 +12,12 @@ variable "account_id" {
   default = ""
 }
 
-variable "whitelist_ips" {
-  type        = list(string)
-  description = "List of whitelisted ip addresses that can access grafana"
+variable "grafana_alb_security_group_id" {
+  description = "id of the security group for the Grafana alb"
+}
 
-  default = ["0.0.0.0/0"]
+variable "grafana_ecs_security_group_id" {
+  description = "id of the security group for the Grafana ecs"
 }
 
 variable "dns_zone" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -82,3 +82,25 @@ variable "grafana_log_level" {
   description = "The log level for the Grafana application"
   default     = "INFO"
 }
+
+variable "oauth_name" {
+  type = string
+  description = "The name to use for OAuth (for identification)"
+}
+
+variable "oauth_domain" {
+  type = string
+  description = "The domain for OAuth. Will be used to call authorize, token, and userinfo endpoints"
+}
+
+variable "oauth_client_id" {
+  type = string
+  description = "The client ID for OAuth"
+}
+
+variable "oauth_client_secret" {
+  type = string
+  description = "The client secret for OAuth"
+}
+
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -84,22 +84,22 @@ variable "grafana_log_level" {
 }
 
 variable "oauth_name" {
-  type = string
+  type        = string
   description = "The name to use for OAuth (for identification)"
 }
 
 variable "oauth_domain" {
-  type = string
+  type        = string
   description = "The domain for OAuth. Will be used to call authorize, token, and userinfo endpoints"
 }
 
 variable "oauth_client_id" {
-  type = string
+  type        = string
   description = "The client ID for OAuth"
 }
 
 variable "oauth_client_secret" {
-  type = string
+  type        = string
   description = "The client secret for OAuth"
 }
 


### PR DESCRIPTION
#### Resolves [ANALYTICS-2752]

## Context 

Add ability configure generic oauth on Grafana

## Summary of Changes
- ~Export ECS security group id in terraform outputs~ Refactor to allow accepting security group id as an input var. The security groups are now spun up in https://github.com/ValidereInc/va_framework/pull/589. This was done to allow creation of a route from the sg to the private VPC endpoints spun up in `va_framework`.
- Added Generic Oauth configuration to Grafana deployment.

## Progress Checklist
A break down of the steps. Useful when the PR is in the draft stage
- [ ] step 1 
- [ ] step n

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Instructions for the Reviewers
What do you expect from the reviewers? E.g. What code should be run to reproduce the results? Is there anything that needs attention? 

## Housekeeping Checklist
- [x] Linked the PR to a Jira ticket?
- [x] Linked the Jira ticket to the PR?
- [x] Checked Draft/vs Ready to Review?
- [x] Tagged the reviewers if Ready for Review?


[ANALYTICS-2752]: https://validere.atlassian.net/browse/ANALYTICS-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ