### PR TITLE
chore(DSE-581): va monitoring db backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tfplan*
 *.tfstate.*
 *.tfstate
 .idea
+.DS_Store

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -4,7 +4,7 @@ locals {
     GF_SERVER_ROOT_URL   = "https://${var.grafana_subdomain}.${var.dns_name}"
     GF_DATABASE_USER     = var.grafana_db_username
     GF_DATABASE_TYPE     = "mysql"
-    GF_DATABASE_HOST     = "${aws_rds_cluster.grafana.endpoint}:3306"
+    GF_DATABASE_HOST     = "${aws_rds_cluster.grafana_encrypted.endpoint}:3306"
     GF_LOG_LEVEL         = var.grafana_log_level
     GF_DATABASE_PASSWORD = random_password.password.result
     ### AUTH

--- a/terraform/grafana.tf
+++ b/terraform/grafana.tf
@@ -23,14 +23,19 @@ locals {
   }
 }
 resource "aws_ecs_cluster" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster
   name = "${var.resource_prefix}-grafana-cluster"
+  tags = var.common_tags
 }
 
 resource "aws_ecr_repository" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository
   name = "${var.resource_prefix}-grafana"
+  tags = var.common_tags
 }
 
 resource "aws_ecs_task_definition" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition
   family = "${var.resource_prefix}-grafana_task_definition"
   container_definitions = jsonencode([
     {
@@ -71,9 +76,12 @@ resource "aws_ecs_task_definition" "grafana" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = var.common_tags
 }
 
 resource "aws_ecs_service" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service
   name            = "${var.resource_prefix}-grafana"
   cluster         = aws_ecs_cluster.grafana.name
   task_definition = aws_ecs_task_definition.grafana.arn
@@ -100,8 +108,12 @@ resource "aws_ecs_service" "grafana" {
   lifecycle {
     ignore_changes = [desired_count]
   }
+
+  tags = var.common_tags
 }
 
 resource "aws_cloudwatch_log_group" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
   name = "${var.resource_prefix}-grafana"
+  tags = var.common_tags
 }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,4 +1,5 @@
 resource "aws_lb" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb
   name            = "${var.resource_prefix}-grafana"
   internal        = "false"
   security_groups = [var.grafana_alb_security_group_id]
@@ -7,14 +8,11 @@ resource "aws_lb" "grafana" {
 
   enable_deletion_protection = false
 
-  tags = {
-    Name        = "${var.resource_prefix}-grafana"
-    Description = "Application Load Balancer for Grafana"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 }
 
 resource "aws_lb_listener" "front_end_http" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener
   load_balancer_arn = aws_lb.grafana.arn
   port              = "80"
   protocol          = "HTTP"
@@ -28,9 +26,11 @@ resource "aws_lb_listener" "front_end_http" {
       status_code = "HTTP_301"
     }
   }
+  tags = var.common_tags
 }
 
 resource "aws_lb_listener" "front_end_https" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener
   load_balancer_arn = aws_lb.grafana.arn
   port              = "443"
   protocol          = "HTTPS"
@@ -41,9 +41,11 @@ resource "aws_lb_listener" "front_end_https" {
     target_group_arn = aws_lb_target_group.grafana.arn
     type             = "forward"
   }
+  tags = var.common_tags
 }
 
 resource "aws_lb_target_group" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group
   name                 = "${var.resource_prefix}-grafana-tg"
   port                 = 3000
   protocol             = "HTTP"
@@ -60,9 +62,5 @@ resource "aws_lb_target_group" "grafana" {
     protocol            = "HTTP"
   }
 
-  tags = {
-    Name        = "${var.resource_prefix}-grafana-tg"
-    Description = "Target Group for Grafana"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,6 @@
 // lb dns
 output "grafana_rds" {
-  value = aws_rds_cluster.grafana_encrypted.endpoint
+  value = aws_rds_cluster.grafana.endpoint
 }
 
 output "grafana_role" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,6 @@
 // lb dns
 output "grafana_rds" {
-  value = aws_rds_cluster.grafana.endpoint
+  value = aws_rds_cluster.grafana_encrypted.endpoint
 }
 
 output "grafana_role" {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -82,8 +82,7 @@ resource "aws_rds_cluster_instance" "grafana" {
   count = "1"
 
   cluster_identifier         = aws_rds_cluster.grafana.id
-  identifier_prefix          = timestamp()
-  identifier                 = "${var.resource_prefix}-grafana-${count.index}"
+  identifier_prefix          = "${var.resource_prefix}-grafana-${count.index}"
   engine                     = "aurora-mysql"
   engine_version             = "5.7.mysql_aurora.2.11.2"
   instance_class             = var.db_instance_type

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -69,7 +69,7 @@ resource "aws_rds_cluster" "grafana" {
   skip_final_snapshot    = true
   kms_key_id             = aws_kms_key.this.key_id
 
-  tags = var.common_tags
+  tags = var.do_backup ? merge(var.common_tags, {"backup-plan": var.common_tags.environment}) : var.common_tags
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -82,7 +82,8 @@ resource "aws_rds_cluster_instance" "grafana" {
   count = "1"
 
   cluster_identifier         = aws_rds_cluster.grafana.id
-  identifier_prefix          = "${var.resource_prefix}-grafana-${count.index}"
+  identifier_prefix          = timestamp()
+  identifier                 = "${var.resource_prefix}-grafana-${count.index}"
   engine                     = "aurora-mysql"
   engine_version             = "5.7.mysql_aurora.2.11.2"
   instance_class             = var.db_instance_type

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -82,6 +82,7 @@ resource "aws_rds_cluster_instance" "grafana" {
   count = "1"
 
   cluster_identifier         = aws_rds_cluster.grafana.id
+  identifier_prefix          = timestamp()
   identifier                 = "${var.resource_prefix}-grafana-${count.index}"
   engine                     = "aurora-mysql"
   engine_version             = "5.7.mysql_aurora.2.11.2"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -67,6 +67,7 @@ resource "aws_rds_cluster" "grafana" {
   db_subnet_group_name   = aws_db_subnet_group.grafana.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
+  kms_key_id             = aws_kms_key.this.arn
 
   tags = var.do_backup ? merge(var.common_tags, {"backup-plan": var.common_tags.environment}) : var.common_tags
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -52,7 +52,7 @@ resource "aws_kms_key" "this" {
 
 resource "aws_kms_alias" "a" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
-  name          = "alias/${var.common_tags.env}-${var.common_tags.service}-s3-kms-key"
+  name          = "alias/${var.common_tags.environment}-${var.common_tags.service}-s3-kms-key"
   target_key_id = aws_kms_key.this.key_id
 }
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -98,16 +98,17 @@ resource "aws_rds_cluster_instance" "grafana" {
 
 resource "aws_rds_cluster" "grafana_encrypted" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
-  database_name          = "grafana"
-  engine                 = "aurora-mysql"
-  engine_version         = "5.7.mysql_aurora.2.11.2"
-  master_username        = var.grafana_db_username
-  master_password        = random_password.password.result
-  storage_encrypted      = true
-  db_subnet_group_name   = aws_db_subnet_group.grafana.name
-  vpc_security_group_ids = [aws_security_group.rds.id]
-  skip_final_snapshot    = true
-  kms_key_id             = aws_kms_key.this.arn
+  database_name           = "grafana"
+  engine                  = "aurora-mysql"
+  engine_version          = "5.7.mysql_aurora.2.11.2"
+  master_username         = var.grafana_db_username
+  master_password         = random_password.password.result
+  storage_encrypted       = true
+  db_subnet_group_name    = aws_db_subnet_group.grafana.name
+  vpc_security_group_ids  = [aws_security_group.rds.id]
+  skip_final_snapshot     = true
+  kms_key_id              = aws_kms_key.this.arn
+  backup_retention_period = 5
 
   tags = var.do_backup ? merge(var.common_tags, { "backup-plan" : var.common_tags.environment }) : var.common_tags
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -82,7 +82,6 @@ resource "aws_rds_cluster_instance" "grafana" {
   count = "1"
 
   cluster_identifier         = aws_rds_cluster.grafana.id
-  identifier_prefix          = timestamp()
   identifier                 = "${var.resource_prefix}-grafana-${count.index}"
   engine                     = "aurora-mysql"
   engine_version             = "5.7.mysql_aurora.2.11.2"

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -56,45 +56,45 @@ resource "aws_kms_alias" "a" {
   target_key_id = aws_kms_key.this.key_id
 }
 
-resource "aws_rds_cluster" "grafana" {
-  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
-  database_name          = "grafana"
-  engine                 = "aurora-mysql"
-  engine_version         = "5.7.mysql_aurora.2.11.2"
-  master_username        = var.grafana_db_username
-  master_password        = random_password.password.result
-  storage_encrypted      = true
-  db_subnet_group_name   = aws_db_subnet_group.grafana.name
-  vpc_security_group_ids = [aws_security_group.rds.id]
-  skip_final_snapshot    = true
+# resource "aws_rds_cluster" "grafana" {
+#   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
+#   database_name          = "grafana"
+#   engine                 = "aurora-mysql"
+#   engine_version         = "5.7.mysql_aurora.2.11.2"
+#   master_username        = var.grafana_db_username
+#   master_password        = random_password.password.result
+#   storage_encrypted      = true
+#   db_subnet_group_name   = aws_db_subnet_group.grafana.name
+#   vpc_security_group_ids = [aws_security_group.rds.id]
+#   skip_final_snapshot    = true
 
-  tags = var.do_backup ? merge(var.common_tags, { "backup-plan" : var.common_tags.environment }) : var.common_tags
+#   tags = var.do_backup ? merge(var.common_tags, { "backup-plan" : var.common_tags.environment }) : var.common_tags
 
-  lifecycle {
-    create_before_destroy = true
-    prevent_destroy       = false
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#     prevent_destroy       = false
+#   }
+# }
 
-resource "aws_rds_cluster_instance" "grafana" {
-  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance
-  count = "1"
+# resource "aws_rds_cluster_instance" "grafana" {
+#   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance
+#   count = "1"
 
-  cluster_identifier         = aws_rds_cluster.grafana.id
-  identifier                 = "${var.resource_prefix}-grafana-${count.index}"
-  engine                     = "aurora-mysql"
-  engine_version             = "5.7.mysql_aurora.2.11.2"
-  instance_class             = var.db_instance_type
-  publicly_accessible        = false
-  db_subnet_group_name       = aws_db_subnet_group.grafana.name
-  auto_minor_version_upgrade = true
+#   cluster_identifier         = aws_rds_cluster.grafana.id
+#   identifier                 = "${var.resource_prefix}-grafana-${count.index}"
+#   engine                     = "aurora-mysql"
+#   engine_version             = "5.7.mysql_aurora.2.11.2"
+#   instance_class             = var.db_instance_type
+#   publicly_accessible        = false
+#   db_subnet_group_name       = aws_db_subnet_group.grafana.name
+#   auto_minor_version_upgrade = true
 
-  tags = var.common_tags
+#   tags = var.common_tags
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
 
 resource "aws_rds_cluster" "grafana_encrypted" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -67,7 +67,7 @@ resource "aws_rds_cluster" "grafana" {
   db_subnet_group_name   = aws_db_subnet_group.grafana.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
-  kms_key_id             = aws_kms_key.this.key_id
+  kms_key_id             = aws_kms_key.this.arn
 
   tags = var.do_backup ? merge(var.common_tags, {"backup-plan": var.common_tags.environment}) : var.common_tags
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -67,7 +67,6 @@ resource "aws_rds_cluster" "grafana" {
   db_subnet_group_name   = aws_db_subnet_group.grafana.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
-  kms_key_id             = aws_kms_key.this.arn
 
   tags = var.do_backup ? merge(var.common_tags, {"backup-plan": var.common_tags.environment}) : var.common_tags
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -43,7 +43,7 @@ resource "aws_secretsmanager_secret_version" "creds" {
 
 resource "aws_kms_key" "this" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
-  description         = "Key used to encrypt data in virtual analyzer monitoring database"
+  description         = "Key used to encrypt data in grafana database"
   enable_key_rotation = true
   multi_region = true
 
@@ -52,7 +52,7 @@ resource "aws_kms_key" "this" {
 
 resource "aws_kms_alias" "a" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
-  name          = "alias/${var.common_tags.environment}-${var.common_tags.service}-s3-kms-key"
+  name          = "alias/${var.common_tags.environment}-${var.common_tags.service}-grafana-kms-key"
   target_key_id = aws_kms_key.this.key_id
 }
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -56,45 +56,45 @@ resource "aws_kms_alias" "a" {
   target_key_id = aws_kms_key.this.key_id
 }
 
-# resource "aws_rds_cluster" "grafana" {
-#   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
-#   database_name          = "grafana"
-#   engine                 = "aurora-mysql"
-#   engine_version         = "5.7.mysql_aurora.2.11.2"
-#   master_username        = var.grafana_db_username
-#   master_password        = random_password.password.result
-#   storage_encrypted      = true
-#   db_subnet_group_name   = aws_db_subnet_group.grafana.name
-#   vpc_security_group_ids = [aws_security_group.rds.id]
-#   skip_final_snapshot    = true
+resource "aws_rds_cluster" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
+  database_name          = "grafana"
+  engine                 = "aurora-mysql"
+  engine_version         = "5.7.mysql_aurora.2.11.2"
+  master_username        = var.grafana_db_username
+  master_password        = random_password.password.result
+  storage_encrypted      = true
+  db_subnet_group_name   = aws_db_subnet_group.grafana.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  skip_final_snapshot    = true
 
-#   tags = var.do_backup ? merge(var.common_tags, { "backup-plan" : var.common_tags.environment }) : var.common_tags
+  tags = var.do_backup ? merge(var.common_tags, { "backup-plan" : var.common_tags.environment }) : var.common_tags
 
-#   lifecycle {
-#     create_before_destroy = true
-#     prevent_destroy       = false
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+  }
+}
 
-# resource "aws_rds_cluster_instance" "grafana" {
-#   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance
-#   count = "1"
+resource "aws_rds_cluster_instance" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance
+  count = "1"
 
-#   cluster_identifier         = aws_rds_cluster.grafana.id
-#   identifier                 = "${var.resource_prefix}-grafana-${count.index}"
-#   engine                     = "aurora-mysql"
-#   engine_version             = "5.7.mysql_aurora.2.11.2"
-#   instance_class             = var.db_instance_type
-#   publicly_accessible        = false
-#   db_subnet_group_name       = aws_db_subnet_group.grafana.name
-#   auto_minor_version_upgrade = true
+  cluster_identifier         = aws_rds_cluster.grafana.id
+  identifier                 = "${var.resource_prefix}-grafana-${count.index}"
+  engine                     = "aurora-mysql"
+  engine_version             = "5.7.mysql_aurora.2.11.2"
+  instance_class             = var.db_instance_type
+  publicly_accessible        = false
+  db_subnet_group_name       = aws_db_subnet_group.grafana.name
+  auto_minor_version_upgrade = true
 
-#   tags = var.common_tags
+  tags = var.common_tags
 
-#   lifecycle {
-#     create_before_destroy = true
-#   }
-# }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
 
 resource "aws_rds_cluster" "grafana_encrypted" {
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "rds" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
   name_prefix = "${var.resource_prefix}-grafana-aurora56"
   description = "RDS Aurora access from internal security groups"
   vpc_id      = var.vpc_id
@@ -13,24 +14,16 @@ resource "aws_security_group" "rds" {
       var.grafana_ecs_security_group_id,
     ]
   }
-
-  tags = {
-    Name        = "${var.resource_prefix}-grafana-aurora56"
-    Description = "RDS Aurora access from internal security groups"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 }
 
 resource "aws_db_subnet_group" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group
   name        = "${var.resource_prefix}-grafana-aurora56"
   description = "Subnets to launch RDS database into"
   subnet_ids  = var.db_subnet_ids
 
-  tags = {
-    Name        = "grafana-aurora56-subnet-group"
-    Description = "Subnets to use for RDS databases"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 }
 
 resource "random_password" "password" {
@@ -49,6 +42,7 @@ resource "aws_secretsmanager_secret_version" "creds" {
 }
 
 resource "aws_rds_cluster" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster
   database_name          = "grafana"
   engine                 = "aurora-mysql"
   engine_version         = "5.7.mysql_aurora.2.11.2"
@@ -58,12 +52,9 @@ resource "aws_rds_cluster" "grafana" {
   db_subnet_group_name   = aws_db_subnet_group.grafana.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
+  kms_key_id             = 
 
-  tags = {
-    Name        = "${var.resource_prefix}-grafana"
-    Description = "RDS Aurora cluster for the grafana environment"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 
   lifecycle {
     create_before_destroy = true
@@ -72,6 +63,7 @@ resource "aws_rds_cluster" "grafana" {
 }
 
 resource "aws_rds_cluster_instance" "grafana" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance
   count = "1"
 
   cluster_identifier         = aws_rds_cluster.grafana.id
@@ -83,11 +75,7 @@ resource "aws_rds_cluster_instance" "grafana" {
   db_subnet_group_name       = aws_db_subnet_group.grafana.name
   auto_minor_version_upgrade = true
 
-  tags = {
-    Name        = "${var.resource_prefix}-grafana-aurora-instance"
-    Description = "RDS Aurora cluster for the grafana environment"
-    ManagedBy   = "Terraform"
-  }
+  tags = var.common_tags
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -126,5 +126,5 @@ variable "cloudflare_record_tags" {
 variable "do_backup" {
   description = "controls whether RDS isntance is backed up through AWS backup via backup-plan tag"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "common_tags" {
   type = object({
     service     = string
-    env         = string
+    environment = string
     managed-via = string
   })
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -126,5 +126,5 @@ variable "cloudflare_record_tags" {
 variable "do_backup" {
   description = "controls whether RDS isntance is backed up through AWS backup via backup-plan tag"
   type        = bool
-  default     = false
+  default     = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -122,3 +122,9 @@ variable "cloudflare_record_tags" {
   description = "Tags for cloudflare DNS record"
   type        = list(string)
 }
+
+variable "do_backup" {
+  description = "controls whether RDS isntance is backed up through AWS backup via backup-plan tag"
+  type        = bool
+  default     = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,11 @@
+variable "common_tags" {
+  type = object({
+    service     = string
+    env         = string
+    managed-via = string
+  })
+}
+
 variable "region" {
   default     = "us-east-1"
   description = "The primary AWS region"
@@ -114,4 +122,3 @@ variable "cloudflare_record_tags" {
   description = "Tags for cloudflare DNS record"
   type        = list(string)
 }
-


### PR DESCRIPTION
#### Resolves [DSE-581](https://validere.atlassian.net/browse/DSE-581)
#### Resolves [DSE-522](https://validere.atlassian.net/browse/DSE-522)

## Instructions for the Reviewers

This is to be reviewed in tandem with https://github.com/ValidereInc/va_monitoring/pull/28

I went through all the steps laid out in the **Progress Checklist** for the development environment. This includes migrating both the grafana db and monitoring db to new encrypted instance, and checking that everything still works. Reviewers should:
- read context and steps taken, and make sure plan makes sense. If there are concerns, please point them out and offer suggestions for alternatives
- sanity check that db instance configurations makes sense (check through console)
- sanity check aws backup looks good
- sanity check that all aspects of monitoring still work 
    - sign into dev instance of grafana https://analytics-monitors-development.corp.validere.xyz/ with password in 1p (`grafana dev`)
    - check dashboard and connection to new database 

## Context 

Adding va monitoring database to aws backup plan. There are two databases to backup:
- the one defined in the module in this repo, which stores the grafana data 
- the one defined in https://github.com/ValidereInc/va_monitoring/, which is the db which stores all the VA data

In addition, we want to add a customer managed KMS keys to both dbs. This actually requires spinning up new database instances entirely, as the kms key cannot be updated on an existing instance. The **Progress Checklist** enumerates the steps taken to achieve this. These steps are most easily taken manually through the console + using terraform command to import state, and so manual intervention will be required in the production environment as well. 

## Summary of Changes
- standardization of tags to align with [tagging guidelines](https://docs.google.com/document/d/13CZ2kvdAABek9WaEzebQaWREPNmmWy3VCpXa60v7NpE/edit#heading=h.cpahp68u9f6f)
- addition of customer managed multi region kms key
- addition of `backup-plan` tag to opt-in to backup plan

## Progress Checklist
Steps taken to back up data and add customer managed kms key

For the grafana database:
- [x] Add customer managed kms key to terraform configuration in this repo (2393342f0888c922448c75543ca53bd9d2d80cc6 and [89bd2aa](https://github.com/ValidereInc/grafana-fargate/pull/6/commits/89bd2aadf03a1e63f87bb93c91050d837df54cd0))
- [x] In the AWS console, follow steps listed [here](https://repost.aws/knowledge-center/update-encryption-key-rds), where:
    - [x] Snapshot of existing db is taken
    - [x] Snapshot is copied and encrypted with new customer managed kms key
    - [x] Snapshot is restored, which creates a new db cluster and instance. The db cluster and instance configurations are specified to be the same as the existing db
- [x] Add resource blocks for the new db cluster and instance in the terraform configuration in this repo (8fd88b94cfd4145974a13707ca9891d281d1246e)
- [x] Use `terraform import <resource> <identifier>` to sync terraform state to new resource already created manually in step 2
- [x] Point grafana instance to new encrypted db instance (bf480976592794f9711df1c185e456967f16e1a5). Ensure data was successfully ported over
- [x] ~~delete old RDS instances through removal from terraform (9eb695e2dac7353456f70ff67542fd896f22105f)~~ (reverted, will be done in follow up PR)
- [x] add `backup-plan: env` tag to new encrypted instance (5ba9d02f53369cf2d7ed103b92d06ff1b90fffa2)

For the VA monitoring database https://github.com/ValidereInc/va_monitoring/pull/28, repeat the above
- [x] add customer managed key
- [x] take snapshot of existing db
- [x] copy snapshot, encrypting with new key
- [x] restore snapshot with same configurations as existing db 
- [x] add resource blocks for new db and cluster + terraform import
- [x] Connect grafana to new db instance and give permissions to use kms key
- [x] Point existing dashboards to new data source. Ensure dashboards still populate with data
- [x] add `backup-plan: env` tag
- [x] ~~delete old RDS instances through removal from terraform~~ (will be done in follow up PR)

In https://github.com/ValidereInc/analytics_serverless_apps:
- [ ] change db arn being written to and add necessary permissions to new db + kms key


Repeat the above for integration, production
- [x] integration
- [x] production

## Risks and Impact of Change
The main risk is data loss if the snapshot and restore is not done correctly. To mitigate against this:
- we will go through above sequence in lower environments first to make sure it works as intended [dev, integration] and QA to ensure:
    - existing VA dashboards are populated with the expected data
    - existing alerts are still stored in the instance
    - existing users can still login
- snapshots will ensure data is backed up





[DSE-291]: https://validere.atlassian.net/browse/DSE-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSE-581]: https://validere.atlassian.net/browse/DSE-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSE-522]: https://validere.atlassian.net/browse/DSE-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ