### PR TITLE
fix(CHB-2989): Update engine version to match deployment

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -71,7 +71,7 @@ resource "aws_rds_cluster" "grafana_encrypted" {
   cluster_identifier      = "${var.common_tags.environment}-grafana-monitoring-db-cluster"
   database_name           = "grafana"
   engine                  = "aurora-mysql"
-  engine_version          = "5.7.mysql_aurora.2.11.2"
+  engine_version          = "5.7.mysql_aurora.2.11.5"
   availability_zones      = var.availability_zones
   master_username         = var.grafana_db_username
   master_password         = var.is_backup ? data.aws_secretsmanager_secret_version.creds[0].secret_string : random_password.password[0].result


### PR DESCRIPTION
#### Resolves [CHB-2989](https://validere.atlassian.net/browse/CHB-2989)

## Context 

DB engine version is out of sync with deployed version, which fails the CI pipeline in `va_monitoring`

## Summary of Changes
- bump RDS engine version

## Additional Considerations
Any additional consequences, side effects, uncertainties stemming from the changes in this PR.

## Instructions for the Reviewers
What do you expect from the reviewers? E.g. What code should be run to reproduce the results? Is there anything that needs attention? 

## Housekeeping Checklist
- [ ] Linked the PR to a Jira ticket?
- [ ] Linked the Jira ticket to the PR?
- [ ] Checked Draft/vs Ready to Review?
- [ ] Tagged the reviewers if Ready for Review?


[CHB-2989]: https://validere.atlassian.net/browse/CHB-2989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ