### PR TITLE
fix(CHB-3478): Drop HTTP headers on load balancer

### DIFF
--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "grafana" {
   idle_timeout    = "3600"
 
   enable_deletion_protection = false
+  drop_invalid_header_fields = true
 
   access_logs {
     bucket  = var.alb_access_logs_bucket_name


### PR DESCRIPTION
[CHB-3478](https://validere.atlassian.net/browse/CHB-3478)

# Context

Security misconfiguration with http headers setting on load balancer

# Summary of changes
- drop HTTP headers in load balancer

[CHB-3478]: https://validere.atlassian.net/browse/CHB-3478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ